### PR TITLE
fix: make noise suppression filter follow bluetooth default source

### DIFF
--- a/home/.config/pipewire/pipewire.conf.d/50-noise-suppression.conf
+++ b/home/.config/pipewire/pipewire.conf.d/50-noise-suppression.conf
@@ -26,10 +26,15 @@ context.modules = [
             capture.props = {
                 node.name = "effect_input.rnnoise_mono"
                 node.passive = true
+                node.dont-reconnect = false
+                node.dont-move = false
+                state.restore-target = false
             }
             playback.props = {
                 node.name = "effect_output.rnnoise_mono"
-                media.class = Audio/Source
+                media.class = Audio/Source/Virtual
+                priority.session = 100
+                priority.driver = 100
             }
         }
     }

--- a/home/.config/wireplumber/wireplumber.conf.d/50-bluetooth-priority.conf
+++ b/home/.config/wireplumber/wireplumber.conf.d/50-bluetooth-priority.conf
@@ -1,3 +1,10 @@
+# Keep source/sink links movable so filter streams can follow default node changes
+wireplumber.settings = {
+  linking.allow-moving-streams = true
+  linking.follow-default-target = true
+  node.restore-default-targets = false
+}
+
 # Set Bluetooth devices as highest priority
 monitor.bluez.rules = [
   {


### PR DESCRIPTION
## Summary
- Disable `node.restore-default-targets` in WirePlumber so Bluetooth (priority 4000) always wins over USB mic (priority 500) as the default source
- Configure RNNoise filter-chain capture node as movable (`node.dont-move = false`, `node.dont-reconnect = false`) so it re-links to the new default source when Bluetooth connects
- Change RNNoise output `media.class` to `Audio/Source/Virtual` with low priority to prevent it from competing as the system default source

## Test plan
- [ ] Restart PipeWire/WirePlumber: `systemctl --user restart pipewire pipewire-pulse wireplumber && wpctl clear-default`
- [ ] Connect Bluetooth headset (Jabra Evolve2 65)
- [ ] Verify `wpctl status` shows Jabra as default source (`*`)
- [ ] Verify `pw-link -l` shows `effect_input.rnnoise_mono` linked to `bluez_input.*` instead of `alsa_input.usb-*`
- [ ] Verify "Noise Canceling source (Mono)" in PulseAudio Volume Control picks up Bluetooth mic audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)